### PR TITLE
Added displayName for debugging purposes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var React = require('react')
 
 module.exports = React.createClass({
 
+  displayName: 'FontAwesome',
+
   propTypes: {
     border: React.PropTypes.bool,
     fixedWidth: React.PropTypes.bool,


### PR DESCRIPTION
Sometimes when I'm debugging using React Dev Tools, this component shows up as "Unknown Component". This simple change will make it say "FontAwesome" instead. 